### PR TITLE
Prevent QR codes from being scanned

### DIFF
--- a/android/src/main/kotlin/com/apptreesoftware/barcodescan/BarcodeScannerActivity.kt
+++ b/android/src/main/kotlin/com/apptreesoftware/barcodescan/BarcodeScannerActivity.kt
@@ -39,7 +39,6 @@ class BarcodeScannerActivity : Activity(), ZXingScannerView.ResultHandler {
         formats.add(BarcodeFormat.EAN_13)
         formats.add(BarcodeFormat.ITF)
         formats.add(BarcodeFormat.PDF_417)
-        formats.add(BarcodeFormat.QR_CODE)
         formats.add(BarcodeFormat.RSS_14)
         formats.add(BarcodeFormat.RSS_EXPANDED)
         formats.add(BarcodeFormat.UPC_A)

--- a/android/src/main/kotlin/com/apptreesoftware/barcodescan/BarcodeScannerActivity.kt
+++ b/android/src/main/kotlin/com/apptreesoftware/barcodescan/BarcodeScannerActivity.kt
@@ -10,6 +10,7 @@ import android.support.v4.content.ContextCompat
 import android.view.Menu
 import android.view.MenuItem
 import com.google.zxing.Result
+import com.google.zxing.BarcodeFormat
 import me.dm7.barcodescanner.zxing.ZXingScannerView
 
 
@@ -27,6 +28,25 @@ class BarcodeScannerActivity : Activity(), ZXingScannerView.ResultHandler {
         super.onCreate(savedInstanceState)
         title = ""
         scannerView = ZXingScannerView(this)
+        var formats : ArrayList<BarcodeFormat> = ArrayList()
+
+        // exclude QR Code, Aztec, Data Matrix and Maxicode
+        formats.add(BarcodeFormat.CODABAR)
+        formats.add(BarcodeFormat.CODE_39)
+        formats.add(BarcodeFormat.CODE_93)
+        formats.add(BarcodeFormat.CODE_128)
+        formats.add(BarcodeFormat.EAN_8);
+        formats.add(BarcodeFormat.EAN_13)
+        formats.add(BarcodeFormat.ITF)
+        formats.add(BarcodeFormat.PDF_417)
+        formats.add(BarcodeFormat.QR_CODE)
+        formats.add(BarcodeFormat.RSS_14)
+        formats.add(BarcodeFormat.RSS_EXPANDED)
+        formats.add(BarcodeFormat.UPC_A)
+        formats.add(BarcodeFormat.UPC_E)
+        formats.add(BarcodeFormat.UPC_EAN_EXTENSION)
+
+        scannerView.setFormats(formats)
         scannerView.setAutoFocus(true)
         setContentView(scannerView)
     }

--- a/android/src/main/kotlin/com/apptreesoftware/barcodescan/BarcodeScannerActivity.kt
+++ b/android/src/main/kotlin/com/apptreesoftware/barcodescan/BarcodeScannerActivity.kt
@@ -35,7 +35,7 @@ class BarcodeScannerActivity : Activity(), ZXingScannerView.ResultHandler {
         formats.add(BarcodeFormat.CODE_39)
         formats.add(BarcodeFormat.CODE_93)
         formats.add(BarcodeFormat.CODE_128)
-        formats.add(BarcodeFormat.EAN_8);
+        formats.add(BarcodeFormat.EAN_8)
         formats.add(BarcodeFormat.EAN_13)
         formats.add(BarcodeFormat.ITF)
         formats.add(BarcodeFormat.PDF_417)

--- a/ios/Classes/BarcodeScannerViewController.m
+++ b/ios/Classes/BarcodeScannerViewController.m
@@ -4,6 +4,7 @@
 
 #import "BarcodeScannerViewController.h"
 #import <MTBBarcodeScanner/MTBBarcodeScanner.h>
+#import <AVFoundation/AVFoundation.h>
 #import "ScannerOverlay.h"
 
 
@@ -41,7 +42,8 @@
                              metrics:nil
                              views:@{@"scanRect": _scanRect}]];
   [_scanRect startAnimating];
-    self.scanner = [[MTBBarcodeScanner alloc] initWithPreviewView:_previewView];
+    self.scanner = [[MTBBarcodeScanner alloc] initWithMetadataObjectTypes:@[AVMetadataObjectTypeCode128Code,AVMetadataObjectTypeCode39Code,AVMetadataObjectTypeCode39Mod43Code,AVMetadataObjectTypeCode93Code,AVMetadataObjectTypeEAN13Code,AVMetadataObjectTypeEAN8Code,AVMetadataObjectTypeInterleaved2of5Code,AVMetadataObjectTypeITF14Code,AVMetadataObjectTypePDF417Code,AVMetadataObjectTypeUPCECode]
+                                               previewView:_previewView];
     self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel target:self action:@selector(cancel)];
   [self updateFlashButton];
 }


### PR DESCRIPTION
In both IOS and Android code, manually hardcode types used to exclude QR codes and MaxiCode. 